### PR TITLE
Fix first-person spear animations for 1.21.130+

### DIFF
--- a/animation_controllers/player.animation_controllers.json
+++ b/animation_controllers/player.animation_controllers.json
@@ -77,6 +77,90 @@
         }
       }
     },
+    "controller.animation.player.melee_spear": {
+        "initial_state": "hold",
+        "states": {
+          "hold": {
+            "animations": [
+              "third_person_melee_spear_hold"
+            ],
+            "transitions": [
+              {
+                "use": "v.item_use_normalized > 0.0"
+              },
+              {
+                "attack": "v.attack_time > 0.0"
+              }
+            ]
+          },
+          "use": {
+            "animations": [
+              "third_person_melee_spear_use"
+            ],
+            "transitions": [
+              {
+                "hold": "v.item_use_normalized == 0.0"
+              }
+            ]
+          },
+          "attack": {
+            "animations": [
+              "third_person_melee_spear_attack"
+            ],
+            "transitions": [
+              {
+                "hold": "v.attack_time == 0.0"
+              },
+              {
+                "use": "v.item_use_normalized > 0.0"
+              }
+            ]
+          }
+        }
+      },
+      "controller.animation.player.first_person_melee_spear": {
+        "initial_state": "hold",
+        "states": {
+          "hold": {
+            "animations": [
+              "first_person_melee_spear_hold"
+            ],
+            "transitions": [
+              {
+                "use": "v.item_use_normalized > 0.0"
+              },
+              {
+                "attack": "v.attack_time > 0.0"
+              }
+            ]
+          },
+          "use": {
+            "animations": [
+              "first_person_melee_spear_use"
+            ],
+            "transitions": [
+              {
+                "hold": "v.item_use_normalized == 0.0"
+              }
+            ]
+          },
+          "attack": {
+            "animations": [
+              "first_person_melee_spear_attack"
+            ],
+            "transitions": [
+              {
+                "hold": "v.attack_time == 0.0"
+              },
+              {
+                "use": "v.item_use_normalized > 0.0"
+              }
+            ],
+            "blend_transition": 0.2,
+            "blend_via_shortest_path": true
+          }
+        }
+      },
     "controller.animation.player.root": {
       "initial_state": "first_person",
       "states": {
@@ -86,7 +170,8 @@
             "first_person_swap_item",
             { "first_person_attack_controller": "(v.attack_time > 0.0) && !q.is_item_name_any('slot.weapon.mainhand', 'minecraft:filled_map')" },
             { "first_person_empty_hand": "!v.is_holding_right" },
-            { "first_person_map_controller": "q.is_item_name_any('slot.weapon.mainhand', 'minecraft:filled_map') || q.is_item_name_any('slot.weapon.offhand', 'minecraft:filled_map')" }
+            { "first_person_map_controller": "q.is_item_name_any('slot.weapon.mainhand', 'minecraft:filled_map') || q.is_item_name_any('slot.weapon.offhand', 'minecraft:filled_map')" },
+            { "first_person_melee_spear_controller": "v.melee_spear_equipped" }
           ],
           "transitions": [
             { "map_player": "v.map_face_icon" },
@@ -128,7 +213,8 @@
             { "menu_pose": "v.is_in_menu" },
             { "tooting_goat_horn": "v.is_tooting_goat_horn" },
             { "holding_brush": "q.is_item_name_any('slot.weapon.mainhand', 'minecraft:brush')" },
-            { "brushing": "v.is_using_brush" }
+            { "brushing": "v.is_using_brush" },
+            { "third_person_melee_spear_controller": "v.melee_spear_equipped" }
           ],
           "transitions": [
             { "first_person": "v.is_first_person" },

--- a/animations/player.first_person.animation.json
+++ b/animations/player.first_person.animation.json
@@ -1,7 +1,7 @@
-// This file was modified by ambient (ambiennt on discord). Do not use or redistribute this file or its contents without explicit permission from the author.
+// This file was modified by ambient (ambient on discord) & BrineFlashYT ( BrineFlashYT on discord). Do not use or redistribute this file or its contents without explicit permission from the authors.
 {
   "format_version" : "1.10.0",
-  "animations": {
+  "animations" : {
     "animation.player.first_person.attack_rotation" : {
       "loop" : true,
       "bones" : {
@@ -28,11 +28,65 @@
         }
       }
     },
-    "animation.player.first_person.swap_item": {
-      "loop": true,
-      "bones": {
-        "leftarm": {
+    "animation.player.first_person.melee_spear_hold" : {
+      "loop" : true,
+      "override_previous_animation": false,
+      "bones" : {
+        "rightarm" : {
+          "position" : [ 13.15, "(v.short_arm_offset_right * 1.8) - 7.45", 10.5 ],
+          "rotation" : [ 95.5, -40, 116.0 ]
+        },
+        "rightitem": {
           "position": [
+              -1.5,
+              "q.get_default_bone_pivot('rightarm',1) - q.get_default_bone_pivot('rightitem',1) - 7.0 + 2.0",
+              "-q.get_default_bone_pivot('rightitem',2) + 3.5"
+          ],
+          "rotation": [ 60.0, 47.5, 0 ]
+        }
+      }
+    },
+    "animation.player.first_person.melee_spear_use" : {
+      "loop" : true,
+      "override_previous_animation": false,
+      "bones" : {
+        "rightarm" : {
+          "position" : [ 13.15, "(v.short_arm_offset_right * 1.8) - 7.45", 10.5 ],
+          "rotation" : [ 95.5, -40.0, 116.0 ]
+        },
+        "rightitem" : {
+          "position" : [
+            "-1.5 + v.fp_melee_spear_use_item_position_x",
+            "q.get_default_bone_pivot('rightarm',1) - q.get_default_bone_pivot('rightitem',1) - 7.0 + 2.0 + v.fp_melee_spear_use_item_position_y",
+            "-q.get_default_bone_pivot('rightitem',2) + 3.5 + v.fp_melee_spear_use_item_position_z"
+          ],
+          "rotation": [ 45.0, "55.0 + v.fp_melee_spear_use_item_rotation_y", "12.5 + v.fp_melee_spear_use_item_rotation_z" ]
+        }
+      }
+    },
+    "animation.player.first_person.melee_spear_attack" : {
+      "loop" : true,
+      "override_previous_animation": false,
+      "bones" : {
+        "rightarm" : {
+          "position" : [ 13.15, "(v.short_arm_offset_right * 1.8) - 7.45", 10.5 ],
+          "rotation" : [ 95.5, -40.0, 116.0 ]
+        },
+        "rightitem" : {
+          "position" : [
+            "-1.5 + v.fp_melee_spear_attack_item_position_x",
+            "q.get_default_bone_pivot('rightarm', 1) - q.get_default_bone_pivot('rightitem', 1) - 7.0 + 2.0 + v.fp_melee_spear_attack_item_position_y",
+            "-q.get_default_bone_pivot('rightitem', 2) + 3.5 + v.fp_melee_spear_attack_item_position_z"
+          ],
+          "rotation" : [ 45.0, "55.0 + v.fp_melee_spear_attack_item_rotation_y", "-12.5 + v.fp_melee_spear_attack_item_rotation_z" ]
+        }
+      }
+    },
+    "animation.player.first_person.swap_item" : {
+      "loop" : true,
+      "bones" : {
+        "leftarm" : {
+          "position" : [
             0.0,
             "q.is_item_name_any('slot.weapon.offhand', 'minecraft:filled_map', 'minecraft:shield') ? 0.0 : (1.0 - c.player_offhand_arm_height) * -10.0",
             0.0
@@ -47,26 +101,26 @@
         }
       }
     },
-    "animation.player.first_person.map_hold": {
-      "loop": true,
-      "bones": {
-        "leftarm": {
-          "position": [
+    "animation.player.first_person.map_hold" : {
+      "loop" : true,
+      "bones" : {
+        "leftarm" : {
+          "position" : [
             -15.5,
             "-7.5 - v.short_arm_offset_left - (v.map_angle * 8.0)",
             "9.0 + v.short_arm_offset_left - (v.map_angle * 8.0)"
           ],
-          "rotation": [
+          "rotation" : [
             37.5,
             -20,
             -150
           ]
         },
         "rightarm": {
-          "position": [
+          "position" : [
             15.5,
-            "-7.0 - v.short_arm_offset_right - (v.map_angle * 8.0)",
-            "8.0 + v.short_arm_offset_right - (v.map_angle * 8.0)"
+            "-7.5 - v.short_arm_offset_left - (v.map_angle * 8.0)",
+            "9.0 + v.short_arm_offset_left - (v.map_angle * 8.0)"
           ],
           "rotation": [
             50,
@@ -76,50 +130,50 @@
         }
       }
     },
-    "animation.player.first_person.map_hold_attack": {
-      "loop": true,
-      "bones": {
-        "leftarm": {
-          "position": [
+    "animation.player.first_person.map_hold_attack" : {
+      "loop" : true,
+      "bones" : {
+        "leftarm" : {
+          "position" : [
             "math.sin(math.pow(v.attack_time, 0.5) * 180.0) * -3.0",
             "math.sin(math.pow(v.attack_time, 0.5) * 360.0) * 3.0",
             "math.sin(math.pow(v.attack_time, 1.0) * 180.0) * 4.0"
           ],
           "rotation": [ "v.map_angle * 90.0", 0, 0 ]
         },
-        "rightarm": {
-          "position": [
+        "rightarm" : {
+          "position" : [
             "math.sin(math.pow(v.attack_time, 0.5) * 180.0) * -8.0",
             "math.sin(math.pow(v.attack_time, 0.5) * 360.0) * 4.5",
             "math.sin(math.pow(v.attack_time, 1.0) * 180.0) * 4.0"
           ],
-          "rotation": [ "v.map_angle * 90.0", 0, 0 ]
+          "rotation" : [ "v.map_angle * 90.0", 0, 0 ]
         }
       }
     },
-    "animation.player.first_person.map_hold_main_hand": {
-      "loop": true,
-      "bones": {
-        "rightarm": {
-          "position" : [
+    "animation.player.first_person.map_hold_main_hand" : {
+      "loop" : true,
+      "bones" : {
+        "rightarm" : {
+          "position" : [ 
             "14.5 - (math.sin(v.attack_time * 180.0) * 2.0)",
             "(v.short_arm_offset_right * 1.5) - 7.0 + (math.sin(math.pow(v.attack_time, 0.5) * 360.0) * 4.0)",
             "9.0 + (math.sin(math.pow(v.attack_time, 0.5) * 180.0) * 3.0)"
           ],
-          "rotation" : [ 90.0, -40.0, 105.0 ]
+          "rotation": [ 90.0, -40.0, 105.0]
         }
       }
     },
-    "animation.player.first_person.map_hold_off_hand": {
-      "loop": true,
-      "bones": {
-        "leftarm": {
-          "position" : [
+    "animation.player.first_person.map_hold_off_hand" : {
+      "loop" : true,
+      "bones" : {
+        "leftarm" : {
+          "position" : [ 
             -14.4,
             "(v.short_arm_offset_left * 1.5) - 7.0",
             9.0
           ],
-          "rotation" : [ -92.5, 135, 77.5 ]
+          "rotation": [ -92.5, 135, 77.5]
         }
       }
     }

--- a/subpacks/default/entity/player.entity.json
+++ b/subpacks/default/entity/player.entity.json
@@ -1,10 +1,9 @@
 // This file was modified by ambient (ambiennt on discord). Do not use or redistribute this file or its contents without explicit permission from the author.
 {
-  "format_version": "1.10.0",
+  "format_version": "1.26.0",
   "minecraft:client_entity": {
     "description": {
       "identifier": "minecraft:player",
-      "min_engine_version": "1.8.0",
       "materials": {
         "default": "entity_alphatest",
         "cape": "entity_alphatest",
@@ -51,8 +50,14 @@
       "scripts": {
         "variables": {
           "variable.short_arm_offset_left": "public",
-          "variable.short_arm_offset_right": "public"
+          "variable.short_arm_offset_right": "public",
+          "variable.fp_melee_spear_use_attachable_rotation_z": "public",
+          "variable.tp_melee_spear_use_attachable_rotation_z": "public",
+          "variable.fp_melee_spear_attack_attachable_rotation_z": "public",
+          "variable.tp_melee_spear_attack_attachable_position_z": "public",
+          "variable.melee_spear_equipped": "public"
         },
+         "should_update_effects_offscreen": "1.0", 
         "scale": "0.9375",
         "initialize": [
           "v.short_arm_offset_left = 0.0;",
@@ -96,7 +101,10 @@
           "v.elytra_sneak_amount = (q.is_sneaking && !q.is_gliding && !q.is_swimming) ? 1.0 : 0.0;",
           "v.head_rot_detached_from_camera = 0.0;",
           "t.head_rot_detached_from_camera = (q.is_sleeping || q.is_riding || q.is_gliding || q.is_swimming || q.is_crawling || v.damage_nearby_mobs); v.looks_at_camera_amount = (v.is_first_person || t.head_rot_detached_from_camera) ? 1.0 : 0.0;",
-          "v.is_valid_player = 0.0;"
+          "v.is_valid_player = 0.0;",
+          "v.melee_spear_equipped = 0.0;",
+          "v.melee_spear_java_to_bedrock_scale = 40.0;",
+          "v.item_use_duration = 0.0;"
         ],
         "pre_animation": [
           // Restrict certain player entities from updating variables that are based on historical values.
@@ -115,8 +123,8 @@
           "v.is_valid_player ? { t.rot_y_delta = q.body_y_rotation - q.head_y_rotation(0); v.relative_cape_rotation = q.is_sleeping ? 0 : (v.modified_move_speed * (math.sqrt(v.modified_move_speed) - math.sqrt(q.cape_flap_amount)) * math.sin(t.rot_y_delta)); };",
           
           "v.is_valid_player ? { v.elytra_tilt_ratio = (q.position_delta(1) < 0) ? 1 - math.pow(-q.movement_direction(1), 1.5) : 1; };",
-          "v.is_valid_player ? { t.lerp_pct = 0.8; t.lerp_time = 0.2; t.elytra_glide_amount_raw = q.is_gliding ? 1.0 : 0.0; v.elytra_glide_amount = v.elytra_glide_amount + (t.elytra_glide_amount_raw - v.elytra_glide_amount) * (1 - math.pow((1 - temp.lerp_pct), q.delta_time / t.lerp_time)); };",
-          "v.is_valid_player ? { t.lerp_pct = 0.8; t.lerp_time = 0.2; t.elytra_sneak_amount_raw = (q.is_sneaking && !q.is_gliding && !q.is_swimming) ? 1.0 : 0.0; v.elytra_sneak_amount = v.elytra_sneak_amount + (t.elytra_sneak_amount_raw - v.elytra_sneak_amount) * (1 - math.pow((1 - temp.lerp_pct), q.delta_time / t.lerp_time)); };",
+          "v.is_valid_player ? { t.lerp_pct = 0.8; t.lerp_time = 0.2; t.elytra_glide_amount_raw = q.is_gliding ? 1.0 : 0.0; v.elytra_glide_amount = v.elytra_glide_amount + (t.elytra_glide_amount_raw - v.elytra_glide_amount) * (1 - math.pow((1 - t.lerp_pct), q.delta_time / t.lerp_time)); };",
+          "v.is_valid_player ? { t.lerp_pct = 0.8; t.lerp_time = 0.2; t.elytra_sneak_amount_raw = (q.is_sneaking && !q.is_gliding && !q.is_swimming) ? 1.0 : 0.0; v.elytra_sneak_amount = v.elytra_sneak_amount + (t.elytra_sneak_amount_raw - v.elytra_sneak_amount) * (1 - math.pow((1 - t.lerp_pct), q.delta_time / t.lerp_time)); };",
 
           "t.dist = (q.is_local_player ? v.modified_distance_moved : q.modified_distance_moved); t.speed = (q.is_local_player ? v.modified_move_speed : q.modified_move_speed); v.tcos0 = (math.cos(t.dist * 38.1971863421) * t.speed / v.gliding_speed_value) * 57.2957795131;",
           
@@ -126,7 +134,60 @@
           "v.helmet_layer_visible = !q.has_head_gear;",
           "v.chest_layer_visible = 1.0;",
           "v.leg_layer_visible = 1.0;",
-          "v.boot_layer_visible = 1.0;"
+          "v.boot_layer_visible = 1.0;",
+          
+          "v.melee_spear_equipped = q.equipped_item_any_tag('slot.weapon.mainhand', 'minecraft:is_spear');",  
+          "v.tp_melee_spear_base_arm_rotation_x = (q.is_swimming || q.is_gliding) ? (-115.0 - q.target_x_rotation) : (q.is_crawling ? -115.0 : -30.0);",  
+  
+          "t.melee_spear_use_finish_raise_tick = v.melee_spear_equipped ? q.kinetic_weapon_delay : 0.0;",  
+          "t.melee_spear_use_start_sway_tick = v.melee_spear_equipped ? t.melee_spear_use_finish_raise_tick + q.kinetic_weapon_dismount_duration : 0.0;",  
+          "t.melee_spear_use_start_lower_tick = v.melee_spear_equipped ? t.melee_spear_use_finish_raise_tick + q.kinetic_weapon_knockback_duration : 0.0;",  
+          "t.melee_spear_use_finish_lower_tick = v.melee_spear_equipped ? t.melee_spear_use_finish_raise_tick + q.kinetic_weapon_damage_duration : 0.0;",  
+          "t.melee_spear_use_raise_progress = math.clamp(math.inverse_lerp(0.0, t.melee_spear_use_finish_raise_tick, v.item_use_duration), 0.0, 1.0);",  
+          "t.melee_spear_use_raise_progress_start = math.clamp(math.inverse_lerp(0.0, 0.5, t.melee_spear_use_raise_progress), 0.0, 1.0);",  
+          "t.melee_spear_use_raise_progress_middle = math.clamp(math.inverse_lerp(0.5, 0.8, t.melee_spear_use_raise_progress), 0.0, 1.0);",  
+          "t.melee_spear_use_raise_progress_end = math.clamp(math.inverse_lerp(0.8, 1.0, t.melee_spear_use_raise_progress), 0.0, 1.0);",  
+          "t.melee_spear_use_sway_progress = math.clamp(math.inverse_lerp(t.melee_spear_use_start_sway_tick, t.melee_spear_use_start_lower_tick, v.item_use_duration), 0.0, 1.0);",  
+          "t.melee_spear_use_lower_progress = math.ease_out_cubic(0.0, 1.0, math.ease_in_out_elastic(0.0, 1.0, math.clamp(math.inverse_lerp(t.melee_spear_use_start_lower_tick, t.melee_spear_use_finish_lower_tick - 5, v.item_use_duration), 0.0, 1.0)));",  
+          "t.melee_spear_use_raise_back_progress = math.clamp(math.inverse_lerp(t.melee_spear_use_finish_lower_tick - 5.0, t.melee_spear_use_finish_lower_tick, v.item_use_duration), 0.0, 1.0);",  
+          "t.melee_spear_use_sway_intensity = math.ease_out_circ(0.0, 2.0, t.melee_spear_use_sway_progress) + math.ease_in_circ(0.0, -2.0, t.melee_spear_use_raise_back_progress);",  
+          "t.melee_spear_use_sway_scale_slow = math.sin(v.item_use_duration * 19.0) * t.melee_spear_use_sway_intensity;",  
+          "t.melee_spear_use_sway_scale_fast = math.sin(v.item_use_duration * 30.0) * t.melee_spear_use_sway_intensity;",  
+  
+          "v.fp_melee_spear_use_item_position_x = (t.melee_spear_use_raise_progress_start * 0.05 + t.melee_spear_use_raise_progress_end * -0.05 + t.melee_spear_use_sway_scale_slow * 0.005) * v.melee_spear_java_to_bedrock_scale;",  
+          "v.fp_melee_spear_use_item_position_y = (t.melee_spear_use_raise_progress_start * -0.075 + t.melee_spear_use_raise_progress_middle * 0.075 + t.melee_spear_use_sway_scale_fast * 0.01) * v.melee_spear_java_to_bedrock_scale;",  
+          "v.fp_melee_spear_use_item_position_z = (t.melee_spear_use_raise_progress_start * 0.05 + t.melee_spear_use_raise_progress_end * -0.05 + t.melee_spear_use_sway_scale_slow * 0.005) * v.melee_spear_java_to_bedrock_scale;",  
+          "v.fp_melee_spear_use_item_rotation_y = t.melee_spear_use_raise_progress * 20.0 + t.melee_spear_use_lower_progress * 20.0 + t.melee_spear_use_sway_scale_slow * 0.5 + t.melee_spear_use_raise_back_progress * -40.0;",  
+          "v.fp_melee_spear_use_item_rotation_z = math.ease_in_out_back(0.0, -60.0, t.melee_spear_use_raise_progress) + t.melee_spear_use_lower_progress * -25.0 + t.melee_spear_use_raise_back_progress * 85.0 + t.melee_spear_use_sway_scale_fast * 0.5;",  
+          "v.fp_melee_spear_use_attachable_rotation_z = math.clamp(math.inverse_lerp(0.5, 0.55, t.melee_spear_use_raise_progress), 0.0, 1.0) * -50.0 + t.melee_spear_use_sway_progress * 90.0 + t.melee_spear_use_raise_back_progress * -40.0;",  
+          "v.tp_melee_spear_use_arm_rotation_x = t.melee_spear_use_raise_progress_start * -40.0 + t.melee_spear_use_raise_progress_middle * 30.0 + t.melee_spear_use_raise_progress_end * -20.0 + t.melee_spear_use_lower_progress * 20.0 + t.melee_spear_use_raise_back_progress * 10.0;",  
+          "v.tp_melee_spear_use_arm_rotation_x = v.tp_melee_spear_use_arm_rotation_x + t.melee_spear_use_sway_scale_slow * 0.6;",  
+          "v.tp_melee_spear_use_arm_rotation_y = t.melee_spear_use_sway_scale_fast * 1.0;",  
+          "v.tp_melee_spear_use_arm_rotation_z = t.melee_spear_use_sway_scale_slow * 0.5;",  
+          "v.tp_melee_spear_use_item_rotation_x = t.melee_spear_use_raise_progress * 60.0 + t.melee_spear_use_raise_back_progress * -60.0;",  
+          "v.tp_melee_spear_use_attachable_rotation_z = t.melee_spear_use_raise_progress * 90.0 + t.melee_spear_use_sway_progress * -90.0;",
+          
+          "t.melee_spear_attack_duration_ratio = 1.0 / q.base_swing_duration;",
+          "t.melee_spear_attack_raise_end = 0.05 * t.melee_spear_attack_duration_ratio;",
+          "t.melee_spear_attack_thrust_end = 0.2 * t.melee_spear_attack_duration_ratio;",
+          "t.melee_spear_attack_recover_start = 1.0 - (0.6 * t.melee_spear_attack_duration_ratio);",
+          "t.melee_spear_attack_raise_progress = math.clamp(math.inverse_lerp(0.0, t.melee_spear_attack_raise_end, v.attack_time), 0.0, 1.0);",
+          "t.melee_spear_attack_thrust_progress = math.clamp(math.inverse_lerp(t.melee_spear_attack_raise_end, t.melee_spear_attack_thrust_end, v.attack_time), 0.0, 1.0);",
+          "t.melee_spear_attack_recover_progress = math.clamp(math.inverse_lerp(t.melee_spear_attack_recover_start, 1.0, v.attack_time), 0.0, 1.0);",
+          "t.melee_spear_attack_raise_scale = math.ease_in_out_sine(0.0, 1.0, t.melee_spear_attack_raise_progress);",
+          "t.melee_spear_attack_thrust_scale = math.ease_in_quad(0.0, 1.0, t.melee_spear_attack_thrust_progress);",
+          "t.melee_spear_attack_recover_scale = math.ease_in_out_expo(0.0, 1.0, t.melee_spear_attack_recover_progress);",
+
+          "v.fp_melee_spear_attack_item_position_x = (t.melee_spear_attack_raise_scale * 0.1 + t.melee_spear_attack_thrust_scale * -0.1) * v.melee_spear_java_to_bedrock_scale;",
+          "v.fp_melee_spear_attack_item_position_y = (t.melee_spear_attack_raise_scale * -0.075 + t.melee_spear_attack_recover_scale * 0.075) * v.melee_spear_java_to_bedrock_scale;",
+          "v.fp_melee_spear_attack_item_position_z = (t.melee_spear_attack_raise_scale * 0.65 + t.melee_spear_attack_thrust_scale * -0.65) * v.melee_spear_java_to_bedrock_scale;",
+          "v.fp_melee_spear_attack_item_rotation_y = t.melee_spear_attack_raise_scale * 20.0 + t.melee_spear_attack_recover_scale * -20.0;",
+          "v.fp_melee_spear_attack_item_rotation_z = t.melee_spear_attack_raise_scale * -60.0 + t.melee_spear_attack_recover_scale * 60.0;",
+          "v.fp_melee_spear_attack_attachable_rotation_z = t.melee_spear_attack_raise_scale * 40.0 + t.melee_spear_attack_recover_scale * -40.0;",
+          "v.tp_melee_spear_attack_arm_rotation_x = t.melee_spear_attack_raise_scale * 90.0 + t.melee_spear_attack_thrust_scale * -120.0 + t.melee_spear_attack_recover_scale * 30.0;",
+          "v.tp_melee_spear_attack_item_rotation_x = t.melee_spear_attack_thrust_scale * 60.0 + t.melee_spear_attack_recover_scale * -60.0;",
+          "v.tp_melee_spear_attack_attachable_position_z = (t.melee_spear_attack_thrust_scale * -0.15 + t.melee_spear_attack_recover_scale * 0.15) * v.melee_spear_java_to_bedrock_scale;",
+          "v.item_use_duration = q.main_hand_item_use_duration > 0.0 ? (q.main_hand_item_max_duration - (q.main_hand_item_use_duration - q.frame_alpha + 1.0)) : 0.0;"
         ],
         "animate": [
           "root",
@@ -230,7 +291,17 @@
         "holding_brush": "animation.humanoid.holding_brush",
         "brushing": "animation.humanoid.brushing",
         "crawling": "animation.player.crawl",
-        "crawling.legs": "animation.player.crawl.legs"
+        "crawling.legs": "animation.player.crawl.legs",
+        
+        "first_person_melee_spear_use": "animation.player.first_person.melee_spear_use",
+        "first_person_melee_spear_hold": "animation.player.first_person.melee_spear_hold",
+        "first_person_melee_spear_attack": "animation.player.first_person.melee_spear_attack",
+        "first_person_melee_spear_controller": "controller.animation.player.first_person_melee_spear",
+
+        "third_person_melee_spear_use": "animation.humanoid.melee_spear_use",
+        "third_person_melee_spear_hold": "animation.humanoid.melee_spear_hold",
+        "third_person_melee_spear_attack": "animation.player.melee_spear_attack",
+        "third_person_melee_spear_controller": "controller.animation.player.melee_spear"
       },
       "render_controllers": [
         { "controller.render.player.first_person_spectator": "v.is_first_person && q.is_spectator" },


### PR DESCRIPTION
This pull request fixes the broken first-person spear animations on newer Minecraft Bedrock versions.

Changes:
- Fixed first-person spear animation controller references.
- Fixed first-person spear hold/use/attack animations.
- Updated player entity references required for the new rendering pipeline.
- Preserved the original Java 1.7 Animations behavior and style.

Tested on Minecraft Bedrock 1.21.130+.

Credit:
Original pack by ambient.
Fix and testing by BrineFlashYT.